### PR TITLE
The fixing the beast recovering

### DIFF
--- a/Source/Vampires/AI_Jobs/MentalState_VampireBeast.cs
+++ b/Source/Vampires/AI_Jobs/MentalState_VampireBeast.cs
@@ -21,7 +21,7 @@ namespace Vampire
             {
                 if (!vampComp.IsVampire)
                     RecoverFromState();
-                if (vampBlood.ShouldRecoverFromBeast)
+                if (!vampBlood.Starving)
                     RecoverFromState();
             }
         }


### PR DESCRIPTION
Right now the beast recovering state is too harsh if its only on full blood, it would be much better if either the vampire is not starving anymore, or blood is above 4.
This patch replaces it with not starving.